### PR TITLE
use cargo to install atuin

### DIFF
--- a/run_once_02_install-ubuntu.sh.tmpl
+++ b/run_once_02_install-ubuntu.sh.tmpl
@@ -11,6 +11,23 @@ curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir "./.local/b
 curl -sS https://starship.rs/install.sh | sh -s -- --yes
 
 # atuin
-bash <(curl https://raw.githubusercontent.com/atuinsh/atuin/main/install.sh)
+if ! command -v cargo &> /dev/null
+then
+  echo "cargo not found! Attempting to install rustup"
+
+  if command -v rustup &> /dev/null
+  then
+    echo "rustup was found, but cargo wasn't. Something is up with your install"
+    exit 1
+  fi
+
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+  source "$HOME/.cargo/env"
+
+  echo "rustup installed! Attempting cargo install"
+fi
+
+cargo install atuin
+# bash <(curl https://raw.githubusercontent.com/atuinsh/atuin/main/install.sh)
 
 {{ end -}}


### PR DESCRIPTION
atuin was not installing in the vscode devcontainer. The install script wanted to be interactive. So I grabbed the cargo version out of install.sh and made it non-interactive.